### PR TITLE
Fix publish workflow version variable

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -42,9 +42,9 @@ jobs:
         if: github.ref == 'refs/heads/main'
         id: version_main
         run: |
-          VERSION=$(cat VERSION.txt)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          VERSION_CLEANED="${VERSION#v}"
+          RELEASE_TAG=$(cat VERSION.txt)
+          echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
+          VERSION_CLEANED="${RELEASE_TAG#v}"
           echo "VERSION_CLEANED=$VERSION_CLEANED" >> $GITHUB_ENV
 
       # When on tag, extract version from tag and clean it
@@ -52,20 +52,20 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         id: tag
         run: |
-          VERSION=${GITHUB_REF#refs/tags/}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          VERSION_CLEANED="${VERSION#v}"
+          RELEASE_TAG=${GITHUB_REF#refs/tags/}
+          echo "version=$RELEASE_TAG" >> $GITHUB_OUTPUT
+          VERSION_CLEANED="${RELEASE_TAG#v}"
           echo "VERSION_CLEANED=$VERSION_CLEANED" >> $GITHUB_ENV
 
       - name: Tag and push release (only on main)
         if: github.ref == 'refs/heads/main'
         run: |
-          if git ls-remote --tags origin | grep -q "refs/tags/${{ env.VERSION }}"; then
+          if git ls-remote --tags origin | grep -q "refs/tags/${{ env.RELEASE_TAG }}"; then
             echo "Tag already exists. Skipping."
             exit 0
           fi
-          git tag ${{ env.VERSION }}
-          git push origin ${{ env.VERSION }}
+          git tag ${{ env.RELEASE_TAG }}
+          git push origin ${{ env.RELEASE_TAG }}
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -87,7 +87,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ steps.tag.outputs.version || env.VERSION }}
+          tag_name: ${{ steps.tag.outputs.version || env.RELEASE_TAG }}
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -95,8 +95,8 @@ jobs:
       - name: Bump to next patch pre-release (only on main)
         if: github.ref == 'refs/heads/main'
         run: |
-          VERSION=${{ env.VERSION }}
-          IFS='.' read -r MAJOR MINOR PATCH <<< "${VERSION#v}"
+          RELEASE_TAG=${{ env.RELEASE_TAG }}
+          IFS='.' read -r MAJOR MINOR PATCH <<< "${RELEASE_TAG#v}"
           NEXT_PATCH=$((PATCH + 1))
           NEXT_VERSION="v${MAJOR}.${MINOR}.${NEXT_PATCH}-pre"
           echo "$NEXT_VERSION" > VERSION.txt
@@ -106,5 +106,5 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           git add VERSION.txt
-          git commit -m "Bump version to ${{ env.NEXT_VERSION }} after release ${{ env.VERSION }}"
+          git commit -m "Bump version to ${{ env.NEXT_VERSION }} after release ${{ env.RELEASE_TAG }}"
           git push origin main || echo "Push blocked (e.g. branch protection)"


### PR DESCRIPTION
## Summary
- rename `VERSION` env variable to `RELEASE_TAG` in workflow
- prevent `dotnet publish` from seeing invalid `v*` version strings

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da13d13508327a411bbf0434d8f4d